### PR TITLE
Fix: Update Recipe DTO Constructor to Fix "Flutter Analyze" Error on CI/CD

### DIFF
--- a/lib/data/dto/recipe_dto.dart
+++ b/lib/data/dto/recipe_dto.dart
@@ -5,12 +5,20 @@ part 'recipe_dto.g.dart';
 
 @JsonSerializable()
 class RecipeDto extends Recipe {
-  RecipeDto(this.id, this.title, this.image) : super(id: id);
-
-  final int id;
-  final String? title;
-  final String? image;
-
+  int _id;
+  String? _title;
+  String? _image;
+  RecipeDto(int id, String title, String image)
+      : _id = id,
+        _title = title,
+        _image = image,
+        super(id: id);
+  @override
+  int get id => _id;
+  @override
+  String? get title => _title;
+  @override
+  String? get image => _image;
   factory RecipeDto.fromJson(Map<String, dynamic> json) =>
       _$RecipeDtoFromJson(json);
   Map<String, dynamic> toJson() => _$RecipeDtoToJson(this);

--- a/lib/data/dto/recipe_dto.dart
+++ b/lib/data/dto/recipe_dto.dart
@@ -8,7 +8,7 @@ class RecipeDto extends Recipe {
   int _id;
   String? _title;
   String? _image;
-  RecipeDto(int id, String title, String image)
+  RecipeDto(int id, String? title, String? image)
       : _id = id,
         _title = title,
         _image = image,

--- a/lib/data/dto/recipe_dto.g.dart
+++ b/lib/data/dto/recipe_dto.g.dart
@@ -8,8 +8,8 @@ part of 'recipe_dto.dart';
 
 RecipeDto _$RecipeDtoFromJson(Map<String, dynamic> json) => RecipeDto(
       json['id'] as int,
-      json['title'] as String?,
-      json['image'] as String?,
+      json['title'] as String,
+      json['image'] as String,
     );
 
 Map<String, dynamic> _$RecipeDtoToJson(RecipeDto instance) => <String, dynamic>{

--- a/lib/data/source/network/spoonacular_api_impl.dart
+++ b/lib/data/source/network/spoonacular_api_impl.dart
@@ -1,3 +1,5 @@
+import 'dart:developer';
+
 import 'package:dio/dio.dart';
 import 'package:flap_app/data/dto/recipe_dto.dart';
 import 'package:flap_app/data/source/network/spoonacular_api.dart';
@@ -36,7 +38,7 @@ class SpoonacularApiImpl implements SpoonacularApi {
       // that falls out of the range of 2xx and is also not 304.
       if (error.response != null) {
         //Uses DioException types to print error message
-        print(error);
+        log(error.toString());
         return Future.value(ErrorRequestResponse(error));
       } else {
         // Something happened in setting up or sending the request that triggered an Error


### PR DESCRIPTION
While setting up CI/CD, an error was caught related to the Recipe_DTO class:

<img width="981" alt="Screenshot 2023-11-06 at 4 06 31 PM" src="https://github.com/bcarterterp/Flap/assets/14029158/33ddf2a0-92ee-4fb1-aeb0-49f6af35e56f">

This error appeared as only a lint error in visual studio but did not pass flutter analyze on CI/CD. We are taking a chance to improve our dart code!

The old  way of initializing RecipeDto: 
<img width="593" alt="Screenshot 2023-11-06 at 4 08 26 PM" src="https://github.com/bcarterterp/Flap/assets/14029158/b85428a8-d7fc-4ec2-8d0a-0fe953444a34">

The new way of initializing RecipeDto: 
<img width="567" alt="Screenshot 2023-11-06 at 4 08 12 PM" src="https://github.com/bcarterterp/Flap/assets/14029158/9a75e227-d4e8-4045-8791-0de32e880946">

The old way was causing an error because the Recipe parent class has final fields (given that this is an entity class we do not want this class to be mutable): 

<img width="573" alt="Screenshot 2023-11-06 at 4 11 01 PM" src="https://github.com/bcarterterp/Flap/assets/14029158/4cf44653-f0f0-40b3-90e6-c3521e4e4e35">

The problem though is that the subclass here (RecipeDto) cannot override these final fields. Instead, we are going to override the parent class's public getters to retrieve from private member variables within RecipeDto. 

*Note: the reason we make these private is because this Dto class is also suppose to be immutable and have its internal data hard to change. 

The end goal of this is to separate a business domain class (Recipe) from the data model (RecipeDto) - but have the dto inherit from the domain class so we can cast the response data to Recipe (while taking advantage of the serialization on the dto). My first implementation was a no-no because when inheriting from Recipe, we cannot override its final fields. 


