### PR TITLE
Fix: Remove Main Files for each Flavor, Update Launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,15 +8,13 @@
             "name": "Dev Flavor",
             "request": "launch",
             "type": "dart",
-            "program": "lib/main_dev.dart",
-            "args": ["--flavor", "dev"]
+            "args": ["--flavor", "dev", "--dart-define", "FLAVOR=dev"]
         },
         {
             "name": "Prod flavor",
             "request": "launch",
             "type": "dart",
-            "program": "lib/main_prod.dart",
-            "args": ["--flavor", "prod"],
+            "args": ["--flavor", "prod", "--dart-define", "FLAVOR=prod"],
         },
         {
             "name": "Run all Unit Tests (Dev Flavor)",

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 ## How to Run and Build for the First Time
 
-- First, create a .env file at the root of the project. This file will include the api key for spoonacular:  
+- First, create a .env file at the root of the project. This file will include the api key for spoonacular (reach out to a code-owner for the spoonacular password. You also can create your own account, this is a free API! ):  
 
     `SPOONACULAR_API_KEY=<insert api key here from 1password>`
   
-- Create generated files from the below command:  
+- We rely on generated code files in this project, so after .env is created - run the below command:  
 
     `flutter pub run build_runner clean && flutter pub run build_runner build --delete-conflicting-outputs`
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
-## How to Run
+## How to Run and Build for the First Time
 
-- First, create a .env file at the root of the project. This file will include the api key for spoonacular: 
- `SPOONACULAR_API_KEY=<insert api key here from 1password>`
+- First, create a .env file at the root of the project. This file will include the api key for spoonacular:  
+
+    `SPOONACULAR_API_KEY=<insert api key here from 1password>`
   
-- Create generated files from the below command:
-  `flutter pub run build_runner clean && flutter pub run build_runner build --delete-conflicting-outputs`
+- Create generated files from the below command:  
+
+    `flutter pub run build_runner clean && flutter pub run build_runner build --delete-conflicting-outputs`
 
 - You can launch the app two ways:
-  - Terminal: Use the below command (substitute 'dev' with the flavor you need)
-  `flutter run --flavor dev --dart-define="FLAVOR=dev" `
-  - Launch from VS Code: In the Run and Debug menu, there will be a drop-down menu with flavors specified - as well as unit tests / integration test build configurations. 
+  - **Terminal**: Use the below command (substitute 'dev' with the flavor you need)  
+
+    `flutter run --flavor dev --dart-define="FLAVOR=dev" `
+  - **Launch from VS Code**: In the Run and Debug menu, there will be a drop-down menu with flavors specified - as well as unit tests / integration test build configurations. 
 
 ## Philosophy
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+## How to Run
+
+- First, create a .env file at the root of the project. This file will include the api key for spoonacular: 
+ `SPOONACULAR_API_KEY=<insert api key here from 1password>`
+  
+- Create generated files from the below command:
+  `flutter pub run build_runner clean && flutter pub run build_runner build --delete-conflicting-outputs`
+
+- You can launch the app two ways:
+  - Terminal: Use the below command (substitute 'dev' with the flavor you need)
+  `flutter run --flavor dev --dart-define="FLAVOR=dev" `
+  - Launch from VS Code: In the Run and Debug menu, there will be a drop-down menu with flavors specified - as well as unit tests / integration test build configurations. 
+
 ## Philosophy
 
 - Code is organic, and changes frequently, so as a team we should be aligned on how it grows, and is maintained. The base architecture should be built keeping [SOLID](https://www.digitalocean.com/community/conceptual-articles/s-o-l-i-d-the-first-five-principles-of-object-oriented-design) in mind. Allowing for flexibility when needed, but also dependable. It should be easy for newer people to ramp up, because no one likes to spend a month just to start contributing. Everyone has ownership of the codebase. Take a look [here](https://www.tatvasoft.com/outsourcing/2022/05/software-development-principles.html) for more direction!

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,17 @@
 import 'dart:async';
 
 import 'package:flap_app/my_app.dart';
+import 'package:flap_app/util/flavor/flavor.dart';
+import 'package:flap_app/util/flavor/flavor_config.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-FutureOr<void> main() async {
+FutureOr<void> main(List<String> arguments) async {
+  const flavor = String.fromEnvironment('FLAVOR', defaultValue: 'dev');
+  if (flavor == "prod") {
+    FlavorConfig.flavor = Flavor.prod;
+  } else {
+    FlavorConfig.flavor = Flavor.dev;
+  }
   runApp(const ProviderScope(child: MyApp()));
 }

--- a/lib/main_dev.dart
+++ b/lib/main_dev.dart
@@ -1,9 +1,0 @@
-import 'package:flap_app/util/flavor/flavor_config.dart';
-import 'package:flap_app/util/flavor/flavor.dart';
-
-import 'main.dart' as runner;
-
-Future<void> main() async {
-  FlavorConfig.flavor = Flavor.dev;
-  await runner.main();
-}

--- a/lib/main_prod.dart
+++ b/lib/main_prod.dart
@@ -1,9 +1,0 @@
-import 'package:flap_app/util/flavor/flavor_config.dart';
-import 'package:flap_app/util/flavor/flavor.dart';
-
-import 'main.dart' as runner;
-
-Future<void> main() async {
-  FlavorConfig.flavor = Flavor.prod;
-  await runner.main();
-}


### PR DESCRIPTION
There was a problem before where running "flutter run --flavor dev" does not actually assign flavors in the project because its not entering via main_dev.dart or main_prod.dart. It was running flavor flags successfully via android studio / xcode but the entry-point into the flutter project was still main.dart. 

This PR changes it so that we enter the app through one main.dart - but we pass command line arguments to specify what flavor to run. 
